### PR TITLE
Enable autoCloseBrackets in CodeMirror editor

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,9 @@ var createEditor = function() {
         indentWithTabs: false,
         theme: "solarized light",
         mode: "javascript",
+        autoCloseBrackets: true,
         extraKeys: {
+            // the following Tab key mapping is from http://codemirror.net/doc/manual.html#keymaps
             Tab: function(cm) {
                 var spaces = Array(cm.getOption("indentUnit") + 1).join(" ");
                 cm.replaceSelection(spaces);


### PR DESCRIPTION
See http://codemirror.net/doc/manual.html#addon_closebrackets for a description. Among other things, this makes it much easier to type the curly braces of functions when they have a new line between them – you can just type <kbd>{</kbd> <kbd>Enter</kbd>.

I also added a comment naming the source of the Tab key map. This explains to readers why that particular implementation for Tab was chosen, instead of a more sophisticated one that indents selected lines when there is a selection.