### PR TITLE
Correctly calculate elevator loadFactor

### DIFF
--- a/elevator.js
+++ b/elevator.js
@@ -185,7 +185,7 @@ var asElevator = function(movable, speedFloorsPerSec, floorCount, floorHeight, m
 
     elevator.getLoadFactor = function() {
         var load = _.reduce(elevator.userSlots, function(sum, slot) { return sum + (slot.user ? slot.user.weight : 0); }, 0);
-        return load / elevator.maxUsers * 100;
+        return load / (elevator.maxUsers * 100);
     }
 
 


### PR DESCRIPTION
This was broken by ac29c30712f587d18c82c44cbf0193b916b00e33, which
introduced an order of operations bug when updating this function to
allow for changing the max number of users per elevator.