### PR TITLE
Fix Elevator Load Factor Normalization

### DIFF
--- a/elevator.js
+++ b/elevator.js
@@ -185,7 +185,7 @@ var asElevator = function(movable, speedFloorsPerSec, floorCount, floorHeight, m
 
     elevator.getLoadFactor = function() {
         var load = _.reduce(elevator.userSlots, function(sum, slot) { return sum + (slot.user ? slot.user.weight : 0); }, 0);
-        return load / elevator.maxUsers * 100;
+        return load / (elevator.maxUsers * 100);
     }
 
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -327,7 +327,6 @@ describe("Elevator object", function() {
 		e.pressFloorButton(3);
 		expect(e.getPressedFloors()).toEqual([2,3]);
 	});
-
 });
 
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -327,6 +327,7 @@ describe("Elevator object", function() {
 		e.pressFloorButton(3);
 		expect(e.getPressedFloors()).toEqual([2,3]);
 	});
+
 });
 
 
@@ -415,6 +416,16 @@ describe("API", function() {
 			expect(elevInterface.goingUpIndicator()).toBe(false);
 			expect(elevInterface.goingDownIndicator()).toBe(false);
 		});
+        
+        it("normalizes load factor", function() {
+            var fnNewUser = function(){ return {weight:_.random(55, 100)}; },
+                fnEnterElevator = function(user){ e.userEntering(user); };
+                
+            _.chain(_.range(20)).map(fnNewUser).forEach(fnEnterElevator);
+            var load = elevInterface.loadFactor();
+            expect(load >= 0 && load <= 1).toBeTruthy();
+            console.log(load);
+        });
 	});
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -416,16 +416,15 @@ describe("API", function() {
 			expect(elevInterface.goingUpIndicator()).toBe(false);
 			expect(elevInterface.goingDownIndicator()).toBe(false);
 		});
-        
-        it("normalizes load factor", function() {
-            var fnNewUser = function(){ return {weight:_.random(55, 100)}; },
-                fnEnterElevator = function(user){ e.userEntering(user); };
-                
-            _.chain(_.range(20)).map(fnNewUser).forEach(fnEnterElevator);
-            var load = elevInterface.loadFactor();
-            expect(load >= 0 && load <= 1).toBeTruthy();
-            console.log(load);
-        });
+
+		it("normalizes load factor", function() {
+			var fnNewUser = function(){ return {weight:_.random(55, 100)}; },
+				fnEnterElevator = function(user){ e.userEntering(user); };
+
+			_.chain(_.range(20)).map(fnNewUser).forEach(fnEnterElevator);
+			var load = elevInterface.loadFactor();
+			expect(load >= 0 && load <= 1).toBeTruthy();
+		});
 	});
 });
 


### PR DESCRIPTION
Introduction of 'max users' to elevator caused its load factor to no longer be normalized between zero and one. I corrected the issue and added a small test to check for normalization.