### PR TITLE
Remove event argument from floor event sample code

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -76,7 +76,7 @@
                     <dd>Listen for the "idle" event issued by the elevator, when the task queue has been emptied and the elevator is doing nothing. In this example we tell it to move to floor 0.</dd>
                 <dt><pre><code>elevator.on("floor_button_pressed", function(floorNum) { ... } );</code></pre></dt>
                     <dd>Listen for the "floor_button_pressed" event, issued when a user pressed a button inside the elevator. This indicates that the user wants to go to that floor.</dd>
-                <dt><pre><code>floor.on("up_button_pressed", function(event) { ... } );</code></pre></dt>
+                <dt><pre><code>floor.on("up_button_pressed", function() { ... } );</code></pre></dt>
                     <dd>Listen for the "up_button_pressed" event, issued when a user pressed the up button on the floor they are waiting on. This indicates that the user wants to go to another floor.</dd>
             </dl>
 


### PR DESCRIPTION
The callback to the floor event is not called with any arguments so this sample code is misleading. Removing the `event` helps inform people the correct use of the function and prevents people from seeing `undefined` errors when attempting to use `event` which doesn't exist.