### PR TITLE
Make CodeMirror reindent lines on paste

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,26 @@ var createEditor = function() {
             }
         }
     });
+    
+    // reindent on paste (adapted from https://github.com/ahuth/brackets-paste-and-indent/blob/master/main.js)
+    cm.on("change", function(codeMirror, change) {
+        if(change.origin !== "paste") {
+            return;
+        }
+        
+        var lineFrom = change.from.line;
+        var lineTo = change.from.line + change.text.length;
+        
+        function reindentLines(codeMirror, lineFrom, lineTo) {
+            codeMirror.operation(function() {
+                codeMirror.eachLine(lineFrom, lineTo, function(lineHandle) {
+                    codeMirror.indentLine(lineHandle.lineNo(), "smart");
+                });
+            });
+        }
+        
+        reindentLines(codeMirror, lineFrom, lineTo);
+    });
 
     var reset = function() {
         cm.setValue($("#default-elev-implementation").text().trim());


### PR DESCRIPTION
I added this feature because I found myself manually reindenting lines of my code after moving them with copy-paste.

I was guided to this implementation by [CodeMirror issue #2120, “Paste with indent?”](https://github.com/codemirror/CodeMirror/issues/2120). I seems that CodeMirror has a culture of add-ons being snippets to copy-paste rather than plugims to include, so that’s what I did.

The project from which this code is adapted, [brackets-paste-and-indent](https://github.com/ahuth/brackets-paste-and-indent/), uses the [Unlicense](http://unlicense.org/), so it is fine to take and adapt code from it. My changes/adaptations were combining the code into one block so that it is more self-contained, and reformatting its style to match the rest of this project.