### PR TITLE
Don't enforce object literals in code

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,8 +66,11 @@ var createEditor = function() {
         var code = cm.getValue();
         var obj;
         try {
+            if (code.substr(0,1) == "{" && code.substr(-1,1) == "}") {
+                code = "(" + code + ")";
+            }
             /* jslint evil:true */
-            obj = eval("(" + code + ")");
+            obj = eval(code);
             /* jshint evil:false */
             console.log("Code is", obj);
             if(typeof obj.init !== "function") {


### PR DESCRIPTION
I'm currently mucking about and using typescript to over-engineer a complex solution.
However, eval automatically surrounding the code in brackets is inconvenient if you're basically working with a block of code. My "solution" is to compensate for the brackets by starting with `function () {})();` and ending with `temp = new Elevator(`, but that's a bit annoying.
This patch only wraps the brackets if the user has provided an object literal.