### PR TITLE
Replay challenge (issue #34)

### DIFF
--- a/app.js
+++ b/app.js
@@ -168,12 +168,18 @@ $(function() {
     };
 
     app.startChallenge = function(challengeIndex, autoStart) {
+        var replayUsers = [];
+
         if(typeof app.world !== "undefined") {
             app.world.unWind();
             // TODO: Investigate if memory leaks happen here
+            if (app.currentChallengeIndex == challengeIndex) {
+                replayUsers = app.world.replayUsers;
+            }
         }
         app.currentChallengeIndex = challengeIndex;
         app.world = app.worldCreator.createWorld(challenges[challengeIndex].options);
+        app.world.replayUsers = replayUsers;
         window.world = app.world;
 
         clearAll([$world, $stats, $feedback]);
@@ -190,10 +196,11 @@ $(function() {
             var challengeStatus = challenges[challengeIndex].condition.evaluate(app.world);
             if(challengeStatus !== null) {
                 app.world.challengeEnded = true;
+                app.world.nextReplayUser = 0;
                 app.worldController.setPaused(true);
                 if(challengeStatus) {
                     presentFeedback($feedback, feedbackTempl, app.world, "Success!", "Challenge completed", createParamsUrl(params, { challenge: (challengeIndex + 2)}));
-
+                    app.world.replayUsers = [];
                 } else {
                     presentFeedback($feedback, feedbackTempl, app.world, "Challenge failed", "Maybe your program needs an improvement?", "");
                 }

--- a/challenges.js
+++ b/challenges.js
@@ -45,18 +45,6 @@ var requireDemo = function() {
     };
 };
 
-var createWeightedSelector = function(weights) {
-    var sum = _.reduce(weights, function(sum, w) { return sum+w; }, 0.0);
-    console.log("Sum is", sum);
-    return function() {
-        var num = _.random(sum, true);
-        var summed = 0;
-        var selectedIndex = 0;
-        _.each(weights, function(w, i) { summed += w; if(num < summed) { selectedIndex = i; return false; } });
-        return selectedIndex;
-    };
-};
-
 /* jshint laxcomma:true */
 var challenges = [
      {options: {floorCount: 3, elevatorCount: 1, spawnRate: 0.3}, condition: requireUserCountWithinTime(15, 60)}

--- a/elevator.js
+++ b/elevator.js
@@ -45,10 +45,14 @@ var asElevator = function(movable, speedFloorsPerSec, floorCount, floorHeight, m
     };
 
     elevator.pressFloorButton = function(floorNumber) {
+        var prev;
         floorNumber = limitNumber(floorNumber, 0, floorCount - 1);
+        prev = elevator.buttonStates[floorNumber];
         elevator.buttonStates[floorNumber] = true;
-        elevator.trigger("floor_button_pressed", floorNumber);
-        elevator.trigger("floor_buttons_changed", elevator.buttonStates);
+        if(!prev) {
+            elevator.trigger("floor_button_pressed", floorNumber);
+            elevator.trigger("floor_buttons_changed", elevator.buttonStates);
+        }
     };
 
     elevator.userExiting = function(user) {

--- a/user.js
+++ b/user.js
@@ -6,6 +6,7 @@ var asUser = function(user, weight, floorCount, floorHeight) {
     user.destinationFloor = 0;
     user.done = false;
     user.removeMe = false;
+    //user.spawnTimestamp = undefined;
 
     user.appearOnFloor = function(floor, destinationFloorNum) {
         var floorPosY = (floorCount - 1) * floorHeight - floor.level * floorHeight + 30;
@@ -21,6 +22,25 @@ var asUser = function(user, weight, floorCount, floorHeight) {
         } else {
             floor.pressUpButton();
         }
+    };
+
+    user.save = function() {
+        return {
+                 spawnTimestamp: user.spawnTimestamp,
+                 weight: user.weight,
+                 spawnFloor: user.currentFloor,
+                 destinationFloor: user.destinationFloor,
+                 displayType: user.displayType,
+                };
+    };
+
+    user.restore = function(savedUser) {
+        user.weight = savedUser.weight;
+        user.currentFloor = savedUser.spawnFloor;
+        user.destinationFloor = savedUser.destinationFloor;
+        user.displayType = savedUser.displayType;
+        user.done = false;
+        user.removeMe = false;
     };
 
     user.elevatorAvailable = function(elevator, floor) {


### PR DESCRIPTION
    Enable replaying a challenge sequence rather than resetting
    
    Restarting a challenge creates a new random sequence of user arrivals
    and floor requests. This means it's possible to pass a given challenge
    simply by retrying after each failure.
    
    Instead, save the sequence of user arrivals and floor requests as they
    are generated. Replay them when we're restarting the same challenge after
    a failure. Navigation to a different challenge or restarting after success
    generates new sequences as before.
    
    Note that saving the sequence of user arrivals and floor requests does
    not perfectly save the failed game for replay since the elevators
    users board, X positions, and the slots users get assigned are
    still randomized. While those attributes can be saved this constitutes
    a reasonable subset that is easy to restore and preserves much of the
    difficulty presented by a given arrival and request sequence.
    
    (see issue #34 )