### PR TITLE
Add stress test challenge with transport count, time limit, and max wait time

### DIFF
--- a/challenges.js
+++ b/challenges.js
@@ -25,6 +25,19 @@ var requireUserCountWithMaxWaitTime = function(userCount, maxWaitTime) {
     };
 };
 
+var requireUserCountWithinTimeWithMaxWaitTime = function(userCount, timeLimit, maxWaitTime) {
+    return {
+       description: "Transport <span class='emphasis-color'>" + userCount + "</span> people in <span class='emphasis-color'>" + timeLimit.toFixed(0) + "</span> seconds or less and let no one wait more than <span class='emphasis-color'>" + maxWaitTime.toFixed(1) + "</span> seconds",
+       evaluate: function(world) {
+            if(world.elapsedTime >= timeLimit || world.maxWaitTime >= maxWaitTime || world.transportedCounter >= userCount) {
+                return world.elapsedTime <= timeLimit && world.maxWaitTime <= maxWaitTime && world.transportedCounter >= userCount;
+            } else {
+                return null;
+            }
+       }
+    };
+};
+
 var requireUserCountWithinMoves = function(userCount, moveLimit) {
     return {
         description: "Transport <span class='emphasis-color'>" + userCount + "</span> people using <span class='emphasis-color'>" + moveLimit + "</span> elevator moves or less",
@@ -79,6 +92,8 @@ var challenges = [
 
     ,{options: {floorCount: 12, elevatorCount: 4, spawnRate: 1.4, elevatorCapacities: [5,10]}, condition: requireUserCountWithinTime(70, 80)}
     ,{options: {floorCount: 21, elevatorCount: 5, spawnRate: 1.9, elevatorCapacities: [10]}, condition: requireUserCountWithinTime(110, 80)}
+
+    ,{options: {floorCount: 21, elevatorCount: 8, spawnRate: 1.5, elevatorCapacities: [6,8]}, condition: requireUserCountWithinTimeWithMaxWaitTime(2675, 1800, 45)}
 
     ,{options: {floorCount: 21, elevatorCount: 8, spawnRate: 1.5, elevatorCapacities: [6,8]}, condition: requireDemo()}
 ];

--- a/test/tests.js
+++ b/test/tests.js
@@ -165,6 +165,20 @@ describe("Challenge requirements", function() {
 			expect(challengeReq.evaluate(fakeWorld)).toBe(true);
 		});
 	});
+        describe("requireUserCountWithinTimeWithMaxWaitTime", function(){
+                it("evaluates correctly", function() {
+                        var challengeReq = requireUserCountWithinTimeWithMaxWaitTime(10, 5.0, 4.0);
+                        expect(challengeReq.evaluate(fakeWorld)).toBe(null);
+                        fakeWorld.elapsedTime = 5.1;
+                        expect(challengeReq.evaluate(fakeWorld)).toBe(false);
+                        fakeWorld.transportedCounter = 11;
+                        expect(challengeReq.evaluate(fakeWorld)).toBe(false);
+                        fakeWorld.elapsedTime = 4.9;
+                        expect(challengeReq.evaluate(fakeWorld)).toBe(true);
+                        fakeWorld.maxWaitTime = 4.1;
+                        expect(challengeReq.evaluate(fakeWorld)).toBe(false);
+                });
+        });
 });
 
 describe("Promise object", function() {


### PR DESCRIPTION
Conceived from trying different solutions within the perpetual demo. This challenge requires the transport rate to converge on the spawn rate within 30 minutes and not have anyone wait more than 45 seconds.