### PR TITLE
Fix elevator moveCount false increment at start

### DIFF
--- a/world.js
+++ b/world.js
@@ -22,6 +22,7 @@ var createWorldCreator = function() {
             elevator.moveTo(currentX, null);
             elevator.setFloorPosition(0);
             elevator.updateDisplayPosition();
+            elevator.moveCount = 0;
             currentX += (20 + elevator.width);
             return elevator;
         });


### PR DESCRIPTION
Fix elevator moveCount false increment at creation of elevators, so game started with world move count = elevator move count * count of elevators